### PR TITLE
Fix Clang-14 build error

### DIFF
--- a/queue.c
+++ b/queue.c
@@ -73,7 +73,7 @@ QueueResult queue_pop(queue_p q)
 	     */
             new_head = (node *) atomic_load(&popped->next);
         }
-        atomic_store(&q->head, (atomic_uintptr_t) new_head);
+        atomic_store(&q->head, (uintptr_t) new_head);
     }
 
     free(popped);
@@ -94,13 +94,13 @@ QueueResult queue_push(queue_p q, void *data)
 
     /* swap the new tail with the old */
     node *old_tail = (node *) atomic_exchange(&q->tail,
-                                              (atomic_uintptr_t) new_tail);
+                                              (uintptr_t) new_tail);
 
     /* link the old tail to the new */
     if (old_tail) {
-        atomic_store(&old_tail->next, (atomic_uintptr_t) new_tail);
+        atomic_store(&old_tail->next, (uintptr_t) new_tail);
     } else {
-        atomic_store(&q->head, (atomic_uintptr_t) new_tail);
+        atomic_store(&q->head, (uintptr_t) new_tail);
     }
     return QUEUE_SUCCESS;
 }


### PR DESCRIPTION
The second argument of atomic_exchange and atomic_store only accept arithmetic or pointer types, not atomic types.

For Clang-14, using (atomic_uintptr_t) would result in build failure.

Fix this issue by changing the type (atomic_uintptr_t) to (uintptr_t).

The error message is

```shell
queue.c:76:32: error: used type 'atomic_uintptr_t' (aka '_Atomic(uintptr_t)') where arithmetic or pointer type is required
        atomic_store(&q->head, (atomic_uintptr_t) new_head);
```

All tests provided in `pc-test` are passed.